### PR TITLE
feat: add auth pages and lock protected sections

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,181 +1,206 @@
-﻿import http from "node:http";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import crypto from "node:crypto";
+﻿import http from "node:http"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import crypto from "node:crypto"
 
-import { createBareServer } from "@tomphttp/bare-server-node";
-import cors from "cors";
-import express from "express";
-import basicAuth from "express-basic-auth";
-import cookieParser from "cookie-parser";
-import mime from "mime";
+import { createBareServer } from "@tomphttp/bare-server-node"
+import cors from "cors"
+import express from "express"
+import basicAuth from "express-basic-auth"
+import cookieParser from "cookie-parser"
+import mime from "mime"
 
-import config from "./config.js";
-import { setupMasqr } from "./Masqr.js";
+import config from "./config.js"
+import { setupMasqr } from "./Masqr.js"
 
-process.on("uncaughtException", (e) => { console.error("uncaughtException:", e); process.exit(1); });
-process.on("unhandledRejection", (e) => { console.error("unhandledRejection:", e); });
+process.on("uncaughtException", (e) => {
+  console.error("uncaughtException:", e)
+  process.exit(1)
+})
+process.on("unhandledRejection", (e) => {
+  console.error("unhandledRejection:", e)
+})
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
-let pool = null;
-const memoryUsers = new Map();
+let pool = null
+const memoryUsers = new Map()
 
 if (process.env.DATABASE_URL) {
   try {
-    const pkg = await import("pg");
-    const { Pool } = pkg;
-    pool = new Pool({ connectionString: process.env.DATABASE_URL });
-    pool.query(
-      "CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)"
-    ).catch((err) => console.error("Failed to ensure users table", err));
+    const pkg = await import("pg")
+    const { Pool } = pkg
+    pool = new Pool({ connectionString: process.env.DATABASE_URL })
+    pool
+      .query("CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)")
+      .catch((err) => console.error("Failed to ensure users table", err))
   } catch (err) {
-    console.error("Failed to load/initialize pg module", err);
+    console.error("Failed to load/initialize pg module", err)
   }
 } else {
-  console.warn("DATABASE_URL not set; using in-memory user store");
+  console.warn("DATABASE_URL not set; using in-memory user store")
 }
 
-const server = http.createServer();
-const app = express();
-const bareServer = createBareServer("/ov/");
-const PORT = Number(process.env.PORT) || 8080;
+const server = http.createServer()
+const app = express()
+const bareServer = createBareServer("/ov/")
+const PORT = Number(process.env.PORT) || 8080
 
-const cache = new Map();
-const CACHE_TTL = 30 * 24 * 60 * 60 * 1000;
+const cache = new Map()
+const CACHE_TTL = 30 * 24 * 60 * 60 * 1000
 
 if (process.env.config === "true" && config?.challenge && config?.users) {
-  console.log(`Password protection is enabled. Users: ${Object.keys(config.users).join(", ")}`);
-  app.use(basicAuth({ users: config.users, challenge: true }));
+  console.log(`Password protection is enabled. Users: ${Object.keys(config.users).join(", ")}`)
+  app.use(basicAuth({ users: config.users, challenge: true }))
 }
 
-app.use(cookieParser());
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use("/ov", cors({ origin: true }));
+app.use(cookieParser())
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+app.use("/ov", cors({ origin: true }))
 
 if (process.env.MASQR === "true") {
-  setupMasqr(app);
+  setupMasqr(app)
 }
 
 app.get("/e/*", async (req, res, next) => {
-  const cached = cache.get(req.path);
+  const cached = cache.get(req.path)
   if (cached && Date.now() - cached.timestamp <= CACHE_TTL) {
-    res.writeHead(200, { "Content-Type": cached.contentType });
-    return res.end(cached.data);
+    res.writeHead(200, { "Content-Type": cached.contentType })
+    return res.end(cached.data)
   }
-  if (cached) cache.delete(req.path);
+  if (cached) cache.delete(req.path)
 
   try {
     const baseUrls = {
       "/e/1/": "https://raw.githubusercontent.com/v-5x/x/fixy/",
       "/e/2/": "https://raw.githubusercontent.com/ypxa/y/main/",
       "/e/3/": "https://raw.githubusercontent.com/ypxa/w/master/",
-    };
+    }
 
-    let reqTarget = null;
+    let reqTarget = null
     for (const [prefix, baseUrl] of Object.entries(baseUrls)) {
       if (req.path.startsWith(prefix)) {
-        reqTarget = baseUrl + req.path.slice(prefix.length);
-        break;
+        reqTarget = baseUrl + req.path.slice(prefix.length)
+        break
       }
     }
-    if (!reqTarget) return next();
+    if (!reqTarget) return next()
 
-    const asset = await fetch(reqTarget);
-    if (!asset.ok) return next();
+    const asset = await fetch(reqTarget)
+    if (!asset.ok) return next()
 
-    const buf = Buffer.from(await asset.arrayBuffer());
-    const ext = path.extname(reqTarget);
-    const binaryOnly = [".unityweb"];
-    const contentType = binaryOnly.includes(ext) ? "application/octet-stream" : (mime.getType(ext) || "application/octet-stream");
+    const buf = Buffer.from(await asset.arrayBuffer())
+    const ext = path.extname(reqTarget)
+    const binaryOnly = [".unityweb"]
+    const contentType = binaryOnly.includes(ext) ? "application/octet-stream" : mime.getType(ext) || "application/octet-stream"
 
-    cache.set(req.path, { data: buf, contentType, timestamp: Date.now() });
-    res.writeHead(200, { "Content-Type": contentType });
-    res.end(buf);
+    cache.set(req.path, { data: buf, contentType, timestamp: Date.now() })
+    res.writeHead(200, { "Content-Type": contentType })
+    res.end(buf)
   } catch (error) {
-    console.error("Asset proxy error:", error);
-    res.status(500).send("Error fetching the asset");
+    console.error("Asset proxy error:", error)
+    res.status(500).send("Error fetching the asset")
   }
-});
+})
 
-app.use(express.static(path.join(__dirname, "static")));
-app.get("/healthz", (_req, res) => res.json({ ok: true }));
+app.use(express.static(path.join(__dirname, "static")))
+app.get("/healthz", (_req, res) => res.json({ ok: true }))
 
 app.post("/api/signup", async (req, res) => {
-  const { username, password } = req.body || {};
-  if (!username || !password) return res.status(400).json({ error: "Missing fields" });
-  const hash = crypto.createHash("sha256").update(password).digest("hex");
+  const { username, password } = req.body || {}
+  if (!username || !password) return res.status(400).json({ error: "Missing fields" })
+  const hash = crypto.createHash("sha256").update(password).digest("hex")
 
   if (!pool) {
-    if (memoryUsers.has(username)) return res.status(409).json({ error: "User already exists" });
-    memoryUsers.set(username, hash);
-    return res.json({ success: true, mode: "memory" });
+    if (memoryUsers.has(username)) return res.status(409).json({ error: "User already exists" })
+    memoryUsers.set(username, hash)
+    return res.json({ success: true, mode: "memory" })
   }
   try {
-    await pool.query("INSERT INTO users (username, password) VALUES ($1,$2)", [username, hash]);
-    res.json({ success: true, mode: "db" });
+    await pool.query("INSERT INTO users (username, password) VALUES ($1,$2)", [username, hash])
+    res.json({ success: true, mode: "db" })
   } catch (err) {
-    if (err?.code === "23505") return res.status(409).json({ error: "User already exists" });
-    console.error("Signup DB error:", err);
-    res.status(500).json({ error: "Server error" });
+    if (err?.code === "23505") return res.status(409).json({ error: "User already exists" })
+    console.error("Signup DB error:", err)
+    res.status(500).json({ error: "Server error" })
   }
-});
+})
 
 app.post("/api/login", async (req, res) => {
-  const { username, password } = req.body || {};
-  if (!username || !password) return res.status(400).json({ error: "Missing fields" });
-  const hash = crypto.createHash("sha256").update(password).digest("hex");
+  const { username, password } = req.body || {}
+  if (!username || !password) return res.status(400).json({ error: "Missing fields" })
+  const hash = crypto.createHash("sha256").update(password).digest("hex")
 
   if (!pool) {
-    const stored = memoryUsers.get(username);
-    if (stored && stored === hash) return res.json({ success: true, mode: "memory" });
-    return res.status(401).json({ error: "Invalid credentials" });
+    const stored = memoryUsers.get(username)
+    if (stored && stored === hash) return res.json({ success: true, mode: "memory" })
+    return res.status(401).json({ error: "Invalid credentials" })
   }
   try {
-    const { rows } = await pool.query("SELECT password FROM users WHERE username=$1", [username]);
-    if (rows.length && rows[0].password === hash) return res.json({ success: true, mode: "db" });
-    return res.status(401).json({ error: "Invalid credentials" });
+    const { rows } = await pool.query("SELECT password FROM users WHERE username=$1", [username])
+    if (rows.length && rows[0].password === hash) return res.json({ success: true, mode: "db" })
+    return res.status(401).json({ error: "Invalid credentials" })
   } catch (err) {
-    console.error("Login DB error:", err);
-    res.status(500).json({ error: "Server error" });
+    console.error("Login DB error:", err)
+    res.status(500).json({ error: "Server error" })
   }
-});
+})
 
-[
+app.post("/api/reset", async (req, res) => {
+  const { username, password } = req.body || {}
+  if (!username || !password) return res.status(400).json({ error: "Missing fields" })
+  const hash = crypto.createHash("sha256").update(password).digest("hex")
+
+  if (!pool) {
+    if (!memoryUsers.has(username)) return res.status(404).json({ error: "User not found" })
+    memoryUsers.set(username, hash)
+    return res.json({ success: true, mode: "memory" })
+  }
+  try {
+    const result = await pool.query("UPDATE users SET password=$2 WHERE username=$1", [username, hash])
+    if (result.rowCount === 0) return res.status(404).json({ error: "User not found" })
+    res.json({ success: true, mode: "db" })
+  } catch (err) {
+    console.error("Reset DB error:", err)
+    res.status(500).json({ error: "Server error" })
+  }
+})
+;[
   { path: "/as", file: "apps.html" },
   { path: "/gm", file: "games.html" },
   { path: "/st", file: "settings.html" },
   { path: "/ta", file: "tabs.html" },
   { path: "/ah", file: "about.html" },
   { path: "/li", file: "login.html" },
-  { path: "/",  file: "index.html" },
+  { path: "/su", file: "signup.html" },
+  { path: "/", file: "index.html" },
   { path: "/tos", file: "tos.html" },
 ].forEach((r) => {
-  app.get(r.path, (_req, res) => res.sendFile(path.join(__dirname, "static", r.file)));
-});
+  app.get(r.path, (_req, res) => res.sendFile(path.join(__dirname, "static", r.file)))
+})
 
-app.use((req, res) => res.status(404).sendFile(path.join(__dirname, "static", "404.html")));
+app.use((req, res) => res.status(404).sendFile(path.join(__dirname, "static", "404.html")))
 app.use((err, req, res, _next) => {
-  console.error("Express error:", err?.stack || err);
-  res.status(500).sendFile(path.join(__dirname, "static", "404.html"));
-});
+  console.error("Express error:", err?.stack || err)
+  res.status(500).sendFile(path.join(__dirname, "static", "404.html"))
+})
 
 server.on("request", (req, res) => {
-  if (bareServer.shouldRoute(req)) bareServer.routeRequest(req, res);
-  else app(req, res);
-});
+  if (bareServer.shouldRoute(req)) bareServer.routeRequest(req, res)
+  else app(req, res)
+})
 server.on("upgrade", (req, socket, head) => {
-  if (bareServer.shouldRoute(req)) bareServer.routeUpgrade(req, socket, head);
-  else socket.end();
-});
+  if (bareServer.shouldRoute(req)) bareServer.routeUpgrade(req, socket, head)
+  else socket.end()
+})
 
 server.on("listening", () => {
-  const addr = server.address();
-  const host = addr && (addr.address === "0.0.0.0" ? "localhost" : addr.address);
-  console.log(`Running at http://${host}:${addr?.port ?? PORT}`);
-});
-server.on("error", (err) => console.error("Server error:", err));
+  const addr = server.address()
+  const host = addr && (addr.address === "0.0.0.0" ? "localhost" : addr.address)
+  console.log(`Running at http://${host}:${addr?.port ?? PORT}`)
+})
+server.on("error", (err) => console.error("Server error:", err))
 
-server.listen(PORT, "0.0.0.0");
+server.listen(PORT, "0.0.0.0")

--- a/manual.txt
+++ b/manual.txt
@@ -1,0 +1,32 @@
+Railway Database Connection Manual
+
+1. Create a Railway project and add the PostgreSQL plugin.
+   - https://railway.app > New Project > Provision PostgreSQL.
+
+2. In the PostgreSQL service settings copy the `DATABASE_URL` value.
+
+3. In the Railway project, open the Variables tab and add:
+   - Key: `DATABASE_URL`
+   - Value: paste the connection string from step 2.
+
+4. Deploy the project so the variable is available to the server.
+
+5. Initialize the database:
+   - Open the PostgreSQL service > `Connect` > `PSQL`.
+   - Run:
+     ```sql
+     CREATE TABLE IF NOT EXISTS users (
+       id SERIAL PRIMARY KEY,
+       username TEXT UNIQUE NOT NULL,
+       password TEXT NOT NULL
+     );
+     ```
+
+6. Start the server (`npm start`). The app will now read `DATABASE_URL` and
+   store users in the Railway database.
+
+Additional manual tasks:
+- If you need to allow password resets, ensure the server is running with the
+  same `DATABASE_URL` so `/api/reset` updates the table.
+- To prevent multiple accounts per device, the browser uses `localStorage`.
+  Clearing site data will remove this restriction.

--- a/static/apps.html
+++ b/static/apps.html
@@ -20,7 +20,7 @@
     <div class="fixed-nav-bar"></div>
     <div id="lock-screen" class="lock-screen">
       <i class="fa-solid fa-lock"></i>
-      <p>Register to unlock</p>
+      <p>Register to access</p>
     </div>
     <div class="mode-toggle">
       <button id="showApps" class="active">Apps</button>
@@ -57,7 +57,9 @@
     <!-- DO NOT REMOVE-->
     <script>
       window.dataLayer = window.dataLayer || []
-      function gtag() { dataLayer.push(arguments) }
+      function gtag() {
+        dataLayer.push(arguments)
+      }
       gtag("js", new Date())
       gtag("config", "G-WKJQ5QHQTJ")
     </script>

--- a/static/assets/css/container.css
+++ b/static/assets/css/container.css
@@ -96,7 +96,7 @@ select {
   display: flex;
   justify-content: center;
   gap: 0.5em;
-  margin-top: 100px;
+  margin-top: 130px;
 }
 
 .mode-toggle button {
@@ -132,4 +132,3 @@ select {
 .status-badge.error {
   color: #d50000;
 }
-

--- a/static/assets/css/login.css
+++ b/static/assets/css/login.css
@@ -53,3 +53,27 @@ body {
 .auth-form button:hover {
   background: var(--tab-hover);
 }
+
+.error-message {
+  color: red;
+  font-size: 0.9rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.auth-toggle {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.switch-link {
+  color: var(--text-primary);
+  text-decoration: underline;
+}

--- a/static/assets/scripts/lock.js
+++ b/static/assets/scripts/lock.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", () => {
   const registered = localStorage.getItem("registered") === "true"
   if (!registered) {
-    window.location.href = "/li"
+    const lockScreen = document.getElementById("lock-screen")
+    if (lockScreen) {
+      lockScreen.style.display = "flex"
+    }
   }
 })

--- a/static/assets/scripts/login.js
+++ b/static/assets/scripts/login.js
@@ -1,37 +1,60 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const signupForm = document.getElementById("signup-form")
   const loginForm = document.getElementById("login-form")
-
-  async function handleAuth(url, username, password) {
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
-    })
-    return res.ok
-  }
-
-  signupForm.addEventListener("submit", async (e) => {
-    e.preventDefault()
-    const username = document.getElementById("signup-username").value.trim()
-    const password = document.getElementById("signup-password").value
-    if (await handleAuth("/api/signup", username, password)) {
-      localStorage.setItem("registered", "true")
-      window.location.href = "/./as"
-    } else {
-      alert("Signup failed")
-    }
-  })
+  const loginError = document.getElementById("login-error")
+  const showReset = document.getElementById("show-reset")
+  const resetForm = document.getElementById("reset-form")
+  const resetError = document.getElementById("reset-error")
 
   loginForm.addEventListener("submit", async (e) => {
     e.preventDefault()
+    loginError.textContent = ""
     const username = document.getElementById("login-username").value.trim()
     const password = document.getElementById("login-password").value
-    if (await handleAuth("/api/login", username, password)) {
-      localStorage.setItem("registered", "true")
-      window.location.href = "/./as"
-    } else {
-      alert("Invalid credentials")
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      })
+      if (res.ok) {
+        localStorage.setItem("registered", "true")
+        window.location.href = "/as"
+      } else {
+        const data = await res.json().catch(() => ({}))
+        loginError.textContent = data.error || "Invalid credentials"
+      }
+    } catch (err) {
+      loginError.textContent = "Network error"
+    }
+  })
+
+  showReset.addEventListener("click", () => {
+    resetForm.style.display = "flex"
+  })
+
+  resetForm.addEventListener("submit", async (e) => {
+    e.preventDefault()
+    resetError.textContent = ""
+    const username = document.getElementById("reset-username").value.trim()
+    const password = document.getElementById("reset-password").value
+    if (password.length < 8) {
+      resetError.textContent = "Password must be at least 8 characters."
+      return
+    }
+    try {
+      const res = await fetch("/api/reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      })
+      if (res.ok) {
+        resetError.textContent = "Password reset. Please login."
+      } else {
+        const data = await res.json().catch(() => ({}))
+        resetError.textContent = data.error || "Reset failed"
+      }
+    } catch (err) {
+      resetError.textContent = "Network error"
     }
   })
 })

--- a/static/assets/scripts/signup.js
+++ b/static/assets/scripts/signup.js
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("signup-form")
+  const error = document.getElementById("signup-error")
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault()
+    error.textContent = ""
+
+    if (localStorage.getItem("accountCreated") === "true") {
+      error.textContent = "An account has already been created on this device."
+      return
+    }
+
+    const username = document.getElementById("signup-username").value.trim()
+    const password = document.getElementById("signup-password").value
+
+    if (password.length < 8) {
+      error.textContent = "Password must be at least 8 characters."
+      return
+    }
+
+    try {
+      const res = await fetch("/api/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      })
+      if (res.ok) {
+        localStorage.setItem("registered", "true")
+        localStorage.setItem("accountCreated", "true")
+        window.location.href = "/as"
+      } else {
+        const data = await res.json().catch(() => ({}))
+        error.textContent = data.error || "Signup failed"
+      }
+    } catch (err) {
+      error.textContent = "Network error"
+    }
+  })
+})

--- a/static/games.html
+++ b/static/games.html
@@ -15,6 +15,10 @@
   </head>
   <body>
     <div class="fixed-nav-bar"></div>
+    <div id="lock-screen" class="lock-screen">
+      <i class="fa-solid fa-lock"></i>
+      <p>Register to access</p>
+    </div>
     <div class="input-container">
       <input type="text" id="searchbarbottom" onkeyup="search_bar()" placeholder="Search" />
       <select id="category" name="category" onchange="show_category()">
@@ -34,6 +38,7 @@
     <script src="./assets/-/config.js?v=5-5-2024"></script>
     <script src="https://kit.fontawesome.com/1237c86ba0.js" crossorigin="anonymous"></script>
     <script src="/assets/scripts/m.js?v=82"></script>
+    <script src="/assets/scripts/lock.js"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
     <!-- DO NOT REMOVE-->
     <script>

--- a/static/login.html
+++ b/static/login.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" id="tab-favicon" href="favicon.png" />
-    <title id="tab-title">Signup / Login</title>
+    <title id="tab-title">Login</title>
     <link rel="stylesheet" href="/assets/css/global.css?v=2" />
     <link rel="stylesheet" href="/assets/css/login.css" />
     <link rel="stylesheet" href="/assets/css/nav.css" />
@@ -16,18 +16,24 @@
   <body>
     <div class="fixed-nav-bar"></div>
     <div class="auth-container">
-      <form id="signup-form" class="auth-form">
-        <h2>Sign Up</h2>
-        <input type="text" id="signup-username" placeholder="Username" required autocomplete="username" />
-        <input type="password" id="signup-password" placeholder="Password" required autocomplete="new-password" />
-        <button type="submit">Sign Up</button>
-      </form>
       <form id="login-form" class="auth-form">
         <h2>Login</h2>
         <input type="text" id="login-username" placeholder="Username" required autocomplete="username" />
         <input type="password" id="login-password" placeholder="Password" required autocomplete="current-password" />
+        <p id="login-error" class="error-message"></p>
         <button type="submit">Login</button>
+        <button type="button" id="show-reset" class="link-button">Forgot Password?</button>
       </form>
+      <form id="reset-form" class="auth-form" style="display: none">
+        <h2>Reset Password</h2>
+        <input type="text" id="reset-username" placeholder="Username" required autocomplete="username" />
+        <input type="password" id="reset-password" placeholder="New Password" required autocomplete="new-password" />
+        <p id="reset-error" class="error-message"></p>
+        <button type="submit">Reset</button>
+      </form>
+    </div>
+    <div class="auth-toggle">
+      <a href="/su" class="switch-link">Sign Up</a>
     </div>
     <script src="/assets/scripts/login.js"></script>
   </body>

--- a/static/settings.html
+++ b/static/settings.html
@@ -18,7 +18,7 @@
     <div class="fixed-nav-bar"></div>
     <div id="lock-screen" class="lock-screen">
       <i class="fa-solid fa-lock"></i>
-      <p>Register to unlock</p>
+      <p>Register to access</p>
     </div>
     <div class="main">
       <div class="settings-container">

--- a/static/signup.html
+++ b/static/signup.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="referrer" content="no-referrer" />
+    <meta http-equiv="X-Frame-Options" content="SAMEORIGIN" />
+    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" id="tab-favicon" href="favicon.png" />
+    <title id="tab-title">Sign Up</title>
+    <link rel="stylesheet" href="/assets/css/global.css?v=2" />
+    <link rel="stylesheet" href="/assets/css/login.css" />
+    <link rel="stylesheet" href="/assets/css/nav.css" />
+    <script src="https://kit.fontawesome.com/1237c86ba0.js" crossorigin="anonymous"></script>
+  </head>
+  <body>
+    <div class="fixed-nav-bar"></div>
+    <div class="auth-container">
+      <form id="signup-form" class="auth-form">
+        <h2>Sign Up</h2>
+        <input type="text" id="signup-username" placeholder="Username" required autocomplete="username" />
+        <input type="password" id="signup-password" placeholder="Password" required autocomplete="new-password" />
+        <p id="signup-error" class="error-message"></p>
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <div class="auth-toggle">
+      <a href="/li" class="switch-link">Login</a>
+    </div>
+    <script src="/assets/scripts/signup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restrict apps, games and settings pages with lock overlay until registered
- add standalone login and signup pages with password reset flow
- document Railway database setup in `manual.txt`

## Testing
- `npm run format`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a987052d008322996cd784a0ababee